### PR TITLE
Remove dot in service email address

### DIFF
--- a/metadata/config/service.json
+++ b/metadata/config/service.json
@@ -4,5 +4,5 @@
   "_type": "config.service",
   "name": "Contact the CICA",
   "phase": "none",
-  "serviceEmailAddress": "general.enquiries@cica.gov.uk."
+  "serviceEmailAddress": "general.enquiries@cica.gov.uk"
 }


### PR DESCRIPTION
Needs to be `general.enquiries@cica.gov.uk`